### PR TITLE
Implement HipKernel wrapper

### DIFF
--- a/include/hip_raii/kernel.hpp
+++ b/include/hip_raii/kernel.hpp
@@ -1,3 +1,52 @@
 #pragma once
 
 #include <hip/hip_runtime.h>
+
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+
+/// RAII style wrapper to simplify HIP kernel launches.
+class HipKernel {
+public:
+    /// Construct a kernel launcher with configuration parameters.
+    /// @param gridDim   Grid dimension used for the launch.
+    /// @param blockDim  Block dimension used for the launch.
+    /// @param sharedMemBytes Shared memory size in bytes.
+    /// @param stream    HIP stream on which the kernel will be launched.
+    HipKernel(dim3 gridDim, dim3 blockDim, std::size_t sharedMemBytes = 0,
+              hipStream_t stream = nullptr)
+        : gridDim_(gridDim),
+          blockDim_(blockDim),
+          sharedMemBytes_(sharedMemBytes),
+          stream_(stream) {}
+
+    /// Launch the specified kernel with the stored configuration.
+    /// Any arguments after @p kernel are forwarded to the underlying kernel.
+    template <typename KernelFunc, typename... Args>
+    void launch(KernelFunc kernel, Args... args) const {
+        hipLaunchKernelGGL(kernel, gridDim_, blockDim_, sharedMemBytes_, stream_,
+                           args...);
+        hipError_t err = hipGetLastError();
+        if (err != hipSuccess) {
+            throw std::runtime_error("hipLaunchKernel failed: " +
+                                     std::string(hipGetErrorString(err)));
+        }
+    }
+
+    /// Getters for configuration parameters.
+    dim3 gridDim() const { return gridDim_; }
+    dim3 blockDim() const { return blockDim_; }
+    std::size_t sharedMemBytes() const { return sharedMemBytes_; }
+    hipStream_t stream() const { return stream_; }
+
+    /// Update the stream used for launches.
+    void setStream(hipStream_t stream) { stream_ = stream; }
+
+private:
+    dim3 gridDim_{};
+    dim3 blockDim_{};
+    std::size_t sharedMemBytes_{};
+    hipStream_t stream_{};
+};
+

--- a/src/example/raii/matrix_multiplication.hip
+++ b/src/example/raii/matrix_multiplication.hip
@@ -13,20 +13,16 @@ std::vector<float> matrix_multiplication_raii(const std::vector<float>& h_A,
             "Input matrices must have compatible sizes.");
     }
 
-    size_t size_A = h_A.size() * sizeof(float);
-    size_t size_B = h_B.size() * sizeof(float);
-    size_t size_C = M * N * sizeof(float);
     constexpr int blockSize = 16;  // Assuming square blocks for simplicity
     dim3 block(blockSize, blockSize);
     dim3 grid((N + blockSize - 1) / blockSize, (M + blockSize - 1) / blockSize);
-    float *d_A = nullptr, *d_B = nullptr, *d_C = nullptr;
     // use RAII to manage device memory
     HipBuffer<float> a(M * K), b(K * N), c(M * N);
     HipStream stream;
     a.copyFromHostAsync(h_A.data(), stream);
     b.copyFromHostAsync(h_B.data(), stream);
-    matrix_multiplication<<<grid, block, 0, stream>>>(a.get(), b.get(), c.get(),
-                                                      M, N, K);
+    HipKernel kernel(grid, block, 0, stream);
+    kernel.launch(matrix_multiplication, a.get(), b.get(), c.get(), M, N, K);
     hipError_t err = hipGetLastError();
     if (err != hipSuccess) {
         throw std::runtime_error("Kernel launch failed: " +

--- a/src/example/raii/vector_add.hip
+++ b/src/example/raii/vector_add.hip
@@ -21,8 +21,8 @@ std::vector<float> vector_add_raii(const std::vector<float>& h_a,
     a.copyFromHostAsync(h_a.data(), stream);
     b.copyFromHostAsync(h_b.data(), stream);
 
-    vector_add<<<numBlocks, blockSize, 0, stream>>>(a.get(), b.get(), c.get(),
-                                                    N);
+    HipKernel kernel(dim3(numBlocks), dim3(blockSize), 0, stream);
+    kernel.launch(vector_add, a.get(), b.get(), c.get(), N);
 
     std::vector<float> h_c(N);
     c.copyToHostAsync(h_c.data(), stream);


### PR DESCRIPTION
## Summary
- implement `HipKernel` class to streamline kernel launches
- update RAII examples to use `HipKernel`

## Testing
- `cmake ..` *(fails: HIP toolchain missing)*

------
https://chatgpt.com/codex/tasks/task_e_68543f55a6b48327a3c8c8eac0f4c455